### PR TITLE
Added note on Secure Gateway Client re Docker

### DIFF
--- a/secure-gateway-connection.md
+++ b/secure-gateway-connection.md
@@ -32,6 +32,7 @@
 ![](docs/step-10.png)
 
 8. On the Clients tab, click on Connect Client and download the appropiate installer for your system. Then run the Secure Gateway Client and enter your Gateway ID and Security Token.
+> If you're planning on using Docker to run the Secure Gateway Client, add `--network=host` to the "docker run" arguments. e.g. `docker run -it --network=host ibmcom/secure-gateway-client <GATEWAY_ID> -t <TOKEN>`. This makes the client connect to the host network (127.0.0.1) properly.
 
 ![](docs/step-11.png)
 ![](docs/step-12.png)


### PR DESCRIPTION
This commit added a note on installing Secure Gateway Client with
Docker. The note explains how to make sure the service reaches the host
network properly by adding `--network=host` to the docker run arguments.

Fixes #1
Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>